### PR TITLE
Changing the logic of the checkCredentials method

### DIFF
--- a/.phpunit.cache/test-results
+++ b/.phpunit.cache/test-results
@@ -1,1 +1,1 @@
-{"version":"pest_2.34.5","defects":[],"times":{"P\\Tests\\ArchTest::__pest_evaluable_it_will_not_use_debugging_functions":0.161,"P\\Tests\\ExampleTest::__pest_evaluable_it_can_test":0.001}}
+{"version":"pest_2.34.7","defects":[],"times":{"P\\Tests\\ExampleTest::__pest_evaluable_it_can_test":0.006,"P\\Tests\\ArchTest::__pest_evaluable_it_will_not_use_debugging_functions":0.084}}

--- a/config/filament-otp-login.php
+++ b/config/filament-otp-login.php
@@ -3,8 +3,6 @@
 return [
     'table_name' => 'otp_codes',
 
-    'user_model' => env('OTP_LOGIN_USER_MODEL', 'App\\Models\\User'),
-
     'otp_code' => [
         'length' => env('OTP_LOGIN_CODE_LENGTH', 6),
         'expires' => env('OTP_LOGIN_CODE_EXPIRES_SECONDS', 120),

--- a/src/Filament/Pages/Login.php
+++ b/src/Filament/Pages/Login.php
@@ -35,7 +35,7 @@ class Login extends BaseLogin
 
     public int $step = 1;
 
-    public int | string $otpCode = '';
+    public int|string $otpCode = '';
 
     public string $email = '';
 
@@ -43,6 +43,7 @@ class Login extends BaseLogin
 
     public function mount(): void
     {
+
         if (Filament::auth()->check()) {
             redirect()->intended(Filament::getUrl());
         }
@@ -88,15 +89,13 @@ class Login extends BaseLogin
     {
         $data = $this->form->getState();
 
-        if (! Filament::auth()->attempt($this->getCredentialsFromFormData($data), $data['remember'] ?? false)) {
-            $this->throwFailureValidationException();
-        }
+        $this->checkCredentials($data);
 
         $user = Filament::auth()->user();
 
         if (
             ($user instanceof FilamentUser) &&
-            (! $user->canAccessPanel(Filament::getCurrentPanel()))
+            (!$user->canAccessPanel(Filament::getCurrentPanel()))
         ) {
             Filament::auth()->logout();
 
@@ -110,11 +109,11 @@ class Login extends BaseLogin
     {
         $code = OtpCode::whereCode($this->data['otp'])->first();
 
-        if (! $code) {
+        if (!$code) {
             throw ValidationException::withMessages([
                 'data.otp' => __('filament-otp-login::translations.validation.invalid_code'),
             ]);
-        } elseif (! $code->isValid()) {
+        } elseif (!$code->isValid()) {
             throw ValidationException::withMessages([
                 'data.otp' => __('filament-otp-login::translations.validation.expired_code'),
             ]);
@@ -149,6 +148,7 @@ class Login extends BaseLogin
 
     public function sendOtp(): void
     {
+
         $this->rateLimiter();
 
         $data = $this->form->getState();
@@ -259,7 +259,7 @@ class Login extends BaseLogin
     {
         return ActionComponent::make('go-back')
             ->label(__('filament-otp-login::translations.view.go_back'))
-            ->action(fn () => $this->goBack());
+            ->action(fn() => $this->goBack());
     }
 
     protected function getAuthenticateFormAction(): Action
@@ -270,7 +270,7 @@ class Login extends BaseLogin
     }
 
     /**
-     * @param  array<string, mixed>  $data
+     * @param array<string, mixed> $data
      * @return array<string, mixed>
      */
     protected function getCredentialsFromFormData(array $data): array
@@ -283,9 +283,7 @@ class Login extends BaseLogin
 
     protected function checkCredentials($data): void
     {
-        $user = config('filament-otp-login.user_model')::where('email', $data['email'])->first();
-
-        if (! $user || ! password_verify($data['password'], $user->password)) {
+        if (!Filament::auth()->attempt($this->getCredentialsFromFormData($data), $data['remember'] ?? false)) {
             $this->throwFailureValidationException();
         }
     }


### PR DESCRIPTION
In my project I use two different guards for each filament panel.

As it is, the first access doesn't work, because I can only place one model.

This way I put it, it will get the default guard from the panel and it will get the provider table.

So there is no longer any need to decide which model to take.