### PR TITLE
Allow custom notification class for people who would like to use othe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ return [
         'length' => env('OTP_LOGIN_CODE_LENGTH', 6), // Length of the OTP code
         'expires' => env('OTP_LOGIN_CODE_EXPIRES_SECONDS', 120), // Expiration time of the OTP code in seconds
     ],
+
+    'notification_class' => \Afsakar\FilamentOtpLogin\Notifications\SendOtpCode::class,
 ];
 
 ```
@@ -119,6 +121,90 @@ use App\Filament\Pages\OverrideLogin;
             ]);
     }
 ```
+
+## Custom Notification Class
+
+If you want to customize the notification, you can replace the `\Afsakar\FilamentOtpLogin\Notifications\SendOtpCode` with your own.
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class SendOtpCode extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct(public string $code)
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail', 'sms'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject(__('filament-otp-login::translations.mail.subject'))
+            ->greeting(__('filament-otp-login::translations.mail.greeting'))
+            ->line(__('filament-otp-login::translations.mail.line1', ['code' => $this->code]))
+            ->line(__('filament-otp-login::translations.mail.line2', ['seconds' => config('filament-otp-login.otp_code.expires')]))
+            ->line(__('filament-otp-login::translations.mail.line3'))
+            ->salutation(__('filament-otp-login::translations.mail.salutation', ['app_name' => config('app.name')]));
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toSms($notifiable)
+    {
+        return [
+            'message' => __("Hello {$notifiable->name}, your OTP code is: {$this->code}"),
+        ];
+    }
+}
+
+```
+
+Then update the config file to use your custom notification class.
+
+```php
+<?php
+return [
+    //... other config options
+
+    'notification_class' => \App\Notifications\SendOtpCode::class,
+];
+
+```
+
 
 ## Testing
 

--- a/config/filament-otp-login.php
+++ b/config/filament-otp-login.php
@@ -1,10 +1,12 @@
 <?php
 
 return [
-    'table_name' => 'otp_codes',
+    'table_name'         => 'otp_codes',
 
-    'otp_code' => [
-        'length' => env('OTP_LOGIN_CODE_LENGTH', 6),
+    'otp_code'           => [
+        'length'  => env('OTP_LOGIN_CODE_LENGTH', 6),
         'expires' => env('OTP_LOGIN_CODE_EXPIRES_SECONDS', 120),
     ],
+
+    'notification_class' => \Afsakar\FilamentOtpLogin\Notifications\SendOtpCode::class,
 ];

--- a/src/Filament/Pages/Login.php
+++ b/src/Filament/Pages/Login.php
@@ -173,7 +173,9 @@ class Login extends BaseLogin
     {
         $this->email = $this->data['email'];
 
-        $this->notify(new SendOtpCode($otpCode));
+        $notificationClass = config('filament-otp-login.notification_class', SendOtpCode::class);
+
+        $this->notify(new $notificationClass($otpCode));
 
         Notification::make()
             ->title(__('filament-otp-login::translations.notifications.title'))


### PR DESCRIPTION
I'd like to use SMS to send out the notifications, because some of my users don't have email addresses. I feel like it would help a lot for myself and other devs to be able to customize the notification class being used; to add their channels of choice, besides just email. 

While in my case I'm doing SMS, any other channel including Whatsapp, Telegram of FCM can be used to send the OTP